### PR TITLE
fix: use pauseRef.current to determine pause action

### DIFF
--- a/src/components/Main.tsx
+++ b/src/components/Main.tsx
@@ -21,7 +21,9 @@ const Main = ({
   loop = false,
   pause = false,
 }: TypistProps) => {
-  const [typedChildrenArray, setTypedChildrenArray] = useState<TypedChildren[]>([]);
+  const [typedChildrenArray, setTypedChildrenArray] = useState<TypedChildren[]>(
+    []
+  );
   const [currentIndex, setCurrentIndex] = useState(-1);
   const clearTimerRef = useRef(emptyFunc);
   const loopRef = useRef(loop);
@@ -88,18 +90,18 @@ const Main = ({
           const actions = getActions(children, splitter);
           if (startDelay > 0) await timeoutPromise(startDelay);
           for (const { type, payload } of actions) {
-            if (pause) await pausePromise();
+            if (pauseRef.current) await pausePromise();
             if (type === 'TYPE_TOKEN') {
-              setCurrentIndex(prev => prev + 1);
+              setCurrentIndex((prev) => prev + 1);
               await timeoutPromise(typingDelay);
             } else if (type === 'BACKSPACE') {
               let amount = payload;
               while (amount--) {
-                setCurrentIndex(prev => prev + 1);
+                setCurrentIndex((prev) => prev + 1);
                 await timeoutPromise(backspaceDelay);
               }
             } else if (type === 'PASTE') {
-              setCurrentIndex(prev => prev + 1);
+              setCurrentIndex((prev) => prev + 1);
             } else if (type === 'DELAY') {
               await timeoutPromise(payload);
             }


### PR DESCRIPTION
## Proposed change

The `pause` prop did not work, the pr is made to fix it.

## Type of change

- [x] Bugfix (non-breaking change which fixes an issue)

## Implementation

Use `pauseRef.current` instead of `pause` to determine whether the typing animation should be paused.

## Additional information

- This PR fixes or closes issue: fixes #
- This PR is related to issue:

## Checklist

- [ ] The code change is tested and works locally.
- [ ] There is no commented-out code in this PR.
