### PR TITLE
fix: do not hide cursor when hideCursorWhenDone prop is false

### DIFF
--- a/src/components/Main.tsx
+++ b/src/components/Main.tsx
@@ -112,7 +112,7 @@ const Main = ({
             }
           }
           onTypingDone?.();
-          setShowCursor(false);
+          if (hideCursorWhenDoneRef.current) setShowCursor(false);
           if (finishDelay > 0) await timeoutPromise(finishDelay);
           if (!loopRef.current) await loopPromise();
         } while (loopRef.current);


### PR DESCRIPTION
## Proposed change

## Type of change

- [ ] Dependency upgrade
- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests
- [ ] Chore (tool changes, configuration changes, and changes to things that do not actually go into production at all)

## Implementation

Added a condition to hide the cursor only when hideCursorWhenDoneRef is false

## Additional information

- This PR fixes or closes issue:
- This PR is related to issue:

## Checklist

- [x] The code change is tested and works locally.
- [x] There is no commented-out code in this PR.
